### PR TITLE
Fix YouTube channel link

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,4 +205,4 @@ When dealing with WhatsApp Business API and wanting to experiment without affect
 This document is provided to you by Datalumina. We help data analysts, engineers, and scientists launch and scale a successful freelance business — $100k+ /year, fun projects, happy clients. If you want to learn more about what we do, you can visit our [website](https://www.datalumina.com/) and subscribe to our [newsletter](https://www.datalumina.com/newsletter). Feel free to share this document with your data friends and colleagues.
 
 ## Tutorials
-For video tutorials, visit the YouTube channel: [youtube.com/@daveebbelaar](youtube.com/@daveebbelaar)
+For video tutorials, visit the YouTube channel: [youtube.com/@daveebbelaar](https://www.youtube.com/@daveebbelaar).


### PR DESCRIPTION
Link was not redirecting correctly.

Currently it redirects users to https://github.com/daveebbelaar/python-whatsapp-bot/blob/main/youtube.com/@daveebbelaar

Thank you for the very helpful project and videos! 🎉